### PR TITLE
fix: update Puppeteer install script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
           run_install: true
 
       - name: Install Chromium
-        run: node node_modules/puppeteer/install.js
+        run: node node_modules/puppeteer/install.mjs
 
       - name: Get country code
         run: pnpm start -- -o ./out/iso-3166-1.csv


### PR DESCRIPTION
## Summary
- fix GitHub Actions Chromium install step to use new Puppeteer install script

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b5729d60908330b2d3a1e72dd6f861